### PR TITLE
return the original element in the callback

### DIFF
--- a/src/rating.js
+++ b/src/rating.js
@@ -122,7 +122,7 @@
 
             container
                 .trigger('set.rating', matchInput.val())
-                .data('rating').callback(rate, e);
+                .data('rating').callback(rate, e, el.parent().parent());
         }
     });
 


### PR DESCRIPTION
By returning the dom element the final user is able to know which rating is triggered. If the input radio elements are inside a regular form, you can use this code to automatically issue the form submit:

```
$('.rating-container').rating(function(vote, e, el) {
  el.parent().submit();
});
```
